### PR TITLE
Expose postgresql port

### DIFF
--- a/ansible/container.yml
+++ b/ansible/container.yml
@@ -85,6 +85,8 @@ services:
     - PGDATA=/var/lib/pgsql/data/userdata
     volumes:
     - postgres-data:/var/lib/pgsql/data
+    expose:
+    - 5432
     options:
       openshift:
         persistent_volume_claims:


### PR DESCRIPTION
Explicitly expose port 5432 so that `shipit` will create a service.